### PR TITLE
add build id to the span id generation

### DIFF
--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -184,7 +184,8 @@ func (l *Listener) handleJob(j types.JobEventPayload) error {
 		return nil
 	}
 	parentTraceID := fmt.Sprint(j.PipelineID)
-	md5HashInBytes := md5.Sum([]byte(j.BuildName))
+	buildNameWithId := fmt.Sprintf("%s%d", j.BuildName, j.BuildID)
+	md5HashInBytes := md5.Sum([]byte(buildNameWithId))
 	md5HashInString := hex.EncodeToString(md5HashInBytes[:])
 	spanID := md5HashInString
 	ev, err := l.createEvent()


### PR DESCRIPTION
At the moment span id is generated using build name only, which means that reruns of a job in a pipeline will have the same span id. Adding build id to the mix should differentiate the reruns.